### PR TITLE
Improve Windows compatibility, improve convenience for "copy"

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -20,6 +20,7 @@ func copyCmd(cmd *cobra.Command, args []string) error {
 
 	markAsAccessed(entry)
 
+	fmt.Printf("URL: %s\n", entry.GetContent("URL"))
 	fmt.Printf("UserName: %s\n", entry.GetContent("UserName"))
 
 	return nil

--- a/entries.go
+++ b/entries.go
@@ -62,6 +62,10 @@ func readEntry(selection string, g *gokeepasslib.Group) (*gokeepasslib.Entry, er
 		return nil, fmt.Errorf("No entry found")
 	}
 
+	if len(entries) == 1 {
+		return readEntry(entries[0], g)
+	}
+
 	for i, entry := range entries {
 		fmt.Printf("%3d %s\n", i, entry)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/tobischo/gokeepasslib/v3"
 	"golang.org/x/crypto/ssh/terminal"
@@ -18,7 +19,7 @@ func readString(text string) (string, error) {
 
 func readPassword(text string) (string, error) {
 	fmt.Print(text)
-	pw, err := terminal.ReadPassword(0)
+	pw, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return "", fmt.Errorf("Failed to read password: '%s'", err)
 	}


### PR DESCRIPTION
The three commits contain three independent changes.

The commit changing the ReadPassword call improves Windows compatibility. This might not work in every situation, though, see https://github.com/regclient/regclient/issues/46#issuecomment-830717789 and https://github.com/golang/go/issues/11914#issuecomment-613715787 for details.

The other two commits are only to improve convenience. If you don't want to mix things up, I can file dedicated pull requests or drop the commits completely.

Thanks a lot for that little tool! :)
